### PR TITLE
Improved parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Please keep in mind the following notes and configuration overrides:
  ES_REGION: The AWS region, e.g. us-west-1, of your Elasticsearch instance
  ES_ENVIRONMENT: A value to append as the `environment` field in each record.
  ES_DEPLOYMENT: A value to append as the `deployment` field in each record.
- ES_BULKSIZE: The number of log lines to bulk index into ES at once. Try 200.
+ ES_BULKSIZE: The number of log lines to bulk index into ES at once. Defaults to 200.
+ ES_TIMESTAMP_FIELD_NAME: The field name of event timestamps. Defaults to `timestamp`.
  ```
 
 * The following authorizations are required:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Please keep in mind the following notes and configuration overrides:
 * When registering the S3 bucket as the data-source in Lambda, add a filter
   for files having `.log.gz` suffix, so that Lambda picks up only apache log files.
 
+* You need to set Lambda environment variables for the following:
+```
+ ES_DOCTYPE: for the `type` field in Elasticsearch
+ ES_ENDPOINT: the FQDN of your AWS Elasticsearch Service
+ ES_INDEX_PREFIX: the prefix for your indices, which will be suffixed with the date
+ ES_REGION: The AWS region, e.g. us-west-1, of your Elasticsearch instance
+ ```
+
 * The following authorizations are required:
 
   1. Lambda permits S3 to push event notification to it

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Please keep in mind the following notes and configuration overrides:
  ES_ENDPOINT: the FQDN of your AWS Elasticsearch Service
  ES_INDEX_PREFIX: the prefix for your indices, which will be suffixed with the date
  ES_REGION: The AWS region, e.g. us-west-1, of your Elasticsearch instance
+ ES_ENVIRONMENT: A value to append as the `environment` field in each record.
+ ES_DEPLOYMENT: A value to append as the `deployment` field in each record.
+ ES_BULKSIZE: The number of log lines to bulk index into ES at once. Try 200.
  ```
 
 * The following authorizations are required:

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Please keep in mind the following notes and configuration overrides:
  ES_ENDPOINT: the FQDN of your AWS Elasticsearch Service
  ES_INDEX_PREFIX: the prefix for your indices, which will be suffixed with the date
  ES_REGION: The AWS region, e.g. us-west-1, of your Elasticsearch instance
- ES_ENVIRONMENT: A value to append as the `environment` field in each record.
- ES_DEPLOYMENT: A value to append as the `deployment` field in each record.
+ ES_EXTRA_FIELDS: A json object with static fields appended to each record. E.g. `{"environment":"foo", "deployment":"bar"}`
  ES_BULKSIZE: The number of log lines to bulk index into ES at once. Try 200.
  ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ and add them to an Amazon Elasticsearch Service domain.
    ```
 
    Verify that these are installed within the `node_modules` subdirectory.
-3. Create a zip file to package the *index.js* and the `node_modules` directory
+3. Update the MaxMind GeoIP DB if you're going to use it:
+```
+cd node_modules/geoip-list && npm run-script updatedb license_key=$MAXMIND_LICENSE_KEY" 
+```
+4. Create a zip file to package the *index.js* and the `node_modules` directory
 
 The zip file thus created is the Lambda Deployment Package.
 
@@ -40,6 +44,7 @@ Please keep in mind the following notes and configuration overrides:
  ES_TIMESTAMP_FIELD_NAME: The field name of event timestamps. Defaults to `timestamp`.
  ES_EXTRA_FIELDS: A json object with static fields appended to each record. E.g. `{"environment":"foo", "deployment":"bar"}`
  ES_BULKSIZE: The number of log lines to bulk index into ES at once. Try 200.
+ GEOIP_LOOKUP_ENABLED: set to "true" if you want to use GeoIP lookup
  ```
 
 * The following authorizations are required:

--- a/index.js
+++ b/index.js
@@ -23,10 +23,10 @@ var indexTimestamp = new Date().toISOString().replace(/\-/g, '.').replace(/T.+/,
 var zlib     = require('zlib');
 /* Globals */
 var esDomain = {
-    endpoint: 'Elasticsearch Endpoint',
-    region: 'us-east-1',
-    index: 'alblogs-' + indexTimestamp, // adds a timestamp to index. Example: alblogs-2015.03.31
-    doctype: 'alb-access-logs'
+    endpoint: process.env.ES_ENDPOINT,
+    region: process.env.ES_REGION,
+    index: process.env.ES_INDEX_PREFIX + '-' + indexTimestamp, // adds a timestamp to index. Example: alblogs-2015.03.31
+    doctype: process.env.ES_DOCTYPE
 };
 var endpoint =  new AWS.Endpoint(esDomain.endpoint);
 var s3 = new AWS.S3();

--- a/index.js
+++ b/index.js
@@ -71,13 +71,20 @@ function s3LogsToES(bucket, key, context, lineStream, recordStream) {
  * (using the "context" parameter).
  */
 function postDocumentToES(doc, context) {
+
+    // Create request object
     var req = new AWS.HttpRequest(endpoint);
+
     req.method = 'POST';
     req.path = path.join('/', esDomain.index, esDomain.doctype);
     req.region = esDomain.region;
     req.body = doc;
+
+    // Set up headers
     req.headers['presigned-expires'] = false;
     req.headers['Host'] = endpoint.host;
+    req.headers['Content-Type'] = 'application/json';
+
     // Sign the request (Sigv4)
     var signer = new AWS.Signers.V4(req, 'es');
     signer.addAuthorization(creds, new Date());

--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ exports.handler = function(event, context) {
         doctype: process.env.ES_DOCTYPE,
         environment: process.env.ES_ENVIRONMENT,
         deployment: process.env.ES_DEPLOYMENT,
-        maxBulkIndexLines: process.env.ES_BULKSIZE // Max Number of log lines to send per bulk interaction with ES
+        maxBulkIndexLines: process.env.ES_BULKSIZE || 200, // Max Number of log lines to send per bulk interaction with ES
+        timestampFieldName: process.env.ES_TIMESTAMP_FIELD_NAME || 'timestamp'
     };
 
     /**
@@ -215,7 +216,7 @@ function parse(line) {
     // but are also quote-enclosed for strings containing spaces.
     var field_names = [
         'type',
-        'timestamp',
+        esDomain.timestampFieldName,
         'elb',
         'client',
         'target',

--- a/index.js
+++ b/index.js
@@ -50,8 +50,7 @@ exports.handler = function(event, context) {
         endpoint: process.env.ES_ENDPOINT,
         index: process.env.ES_INDEX_PREFIX + '-' + indexTimestamp, // adds a timestamp to index. Example: alblogs-2015.03.31
         doctype: process.env.ES_DOCTYPE,
-        environment: process.env.ES_ENVIRONMENT,
-        deployment: process.env.ES_DEPLOYMENT,
+        extraFields: JSON.parse(process.env.ES_EXTRA_FIELDS || '{}'),
         maxBulkIndexLines: process.env.ES_BULKSIZE // Max Number of log lines to send per bulk interaction with ES
     };
 
@@ -94,8 +93,7 @@ exports.handler = function(event, context) {
         var logRecord = parse(line.toString());
 
         // Add standard fields to help with searching
-        logRecord['environment'] = esDomain.environment;
-        logRecord['deployment'] = esDomain.deployment;
+        Object.assign(logRecord, esDomain.extraFields);
 
         var serializedRecord = JSON.stringify(logRecord);
         this.push(serializedRecord);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "maintainers": [
     {
-      "name": "pavan kumar koneru",
+      "name": "pavan kumar koneru"
     }
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,20 @@
 {
-  "name": "s3_lambda_es",
-  "description": "AWS Lambda to get ALB log files from S3 and parse them to ES",
-  "version": "1.0.0",
+  "name": "s3_lambda_es_bulk",
+  "description": "AWS Lambda to get ALB log files from S3 and parse them to ES with bulk indexing",
+  "version": "2.0.0",
   "maintainers": [
     {
-      "name": "pavan kumar koneru"
+      "name": "Mike Sollanych"
     }
   ],
   "dependencies": {
-    "aws-sdk": "2.2.48",
+    "aws-sdk": ">=2.138.0",
     "path": "0.12.7",
     "stream": "0.0.2",
-    "byline": "4.2.1"
+    "byline": "4.2.1",
+    "elasticsearch": "15.1.1",
+    "http-aws-es": "6.0.0"
   },
-  "repository": "https://github.com/pavan3401/aws-elb-logs-to-elasticsearch.git",
+  "repository": "https://github.com/mike-sol/ALB-Logs-to-Elasticsearch",
   "license": "Amazon Software License"
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "path": "0.12.7",
     "stream": "0.0.2",
     "byline": "4.2.1",
-    "elasticsearch": "15.1.1",
-    "http-aws-es": "6.0.0"
+    "elasticsearch": "15.5.0",
+    "http-aws-es": "6.0.0",
+    "geoip-lite": "1.4.0"
   },
   "repository": "https://github.com/mike-sol/ALB-Logs-to-Elasticsearch",
   "license": "Amazon Software License"


### PR DESCRIPTION
The old parse() method had issues with logs that were missing some fields (the space-surrounded `-` as a blank field did not work when the parser expected a `:` separating the fields).

This method seems to work for all ALB logs I've come across so far. 

I've also added support for environment variables for the Elasticsearch instance.